### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,6 +18,8 @@ jobs:
   test:
     name: Integration test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: ./
@@ -35,6 +37,9 @@ jobs:
   cd:
     name: Validate and Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fixes for 2 code scanning alerts from the [PD-7479: GH Actions workflow permissions](https://github.com/orgs/Class-Foundations/security/campaigns/1) security campaign:
- https://github.com/Class-Foundations/gh-action-version-cat/security/code-scanning/2
To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:

  1. The `test` job only needs to read the repository contents, so it should have `contents: read`.
  2. The `cd` job performs actions like creating a release and pushing tags, which require `contents: write` and `packages: write`.

  The `permissions` block can be added at the job level to ensure each job has only the permissions it needs.

  ---
  


- https://github.com/Class-Foundations/gh-action-version-cat/security/code-scanning/1
To fix the issue, we will add a `permissions` block to the workflow. This block will be added at the root level to apply to all jobs, ensuring that the `GITHUB_TOKEN` has the least privileges required. For this workflow:
  - The `test` job only needs `contents: read` to check out the repository.
  - The `cd` job requires additional permissions:
  - `contents: write` for tagging and pushing changes.
  - `packages: write` for creating releases.

  We will explicitly define these permissions to adhere to the principle of least privilege.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
